### PR TITLE
Adding chrisdennis as publisher

### DIFF
--- a/quartz-scheduler_publishers.txt
+++ b/quartz-scheduler_publishers.txt
@@ -14,3 +14,4 @@ Publisher Name, Publisher GitHub.com username, Email adress/contact, Date Added
 James House, jhouserizer, james.house@gmail.com, 23-07-2021
 Biswajit Bhuyan, vionixt, biswajit.cs07@gmail.com, 30-07-2021 
 Mathieu Carbou, mathieucarbou, mathieu.carbou@gmail.com, 30-07-2021
+Chris Dennis, chrisdennis, chris.w.dennis@gmail.com, 30-07-2021


### PR DESCRIPTION
Signed-off-by: Chris Dennis <chris.w.dennis@gmail.com>

In adding my name to the list of publishers, I agree to the current Software AG contributor 
agreement as referred to here: https://github.com/quartz-scheduler/contributing/CONTRIBUTING.md.
I also agree to follow all of the responsibilities and policies pertaining to being a project
"Publisher", as listed in the same document.
